### PR TITLE
Changes for running in google cloud

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+headersFile=~/proj/hackweek/2023-q2/testhook.hdrs
+rqstFile=~/proj/hackweek/2023-q2/testhook.json
+method=POST
+concrrnt=100
+num=10000
+headers=$(awk -F'\n' '{printf "-H \""$1"\" " }' ${headersFile} )
+uri=
+
+
+bash -c "ab -r -s 10 -T \"application/json\" -p \"${rqstFile}\" -m $method $headers -n $num -c $concrrnt https://us-central1-sqsp-gcp-sandbox-001.cloudfunctions.net/task-list-completed" 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+const { createNodeMiddleware, createProbot } = require("probot");
+const app = require("./taskreader");
+
+exports.probotApp = createNodeMiddleware(app, { probot: createProbot() });

--- a/package.json
+++ b/package.json
@@ -11,19 +11,22 @@
   "scripts": {
     "dev-debug": "nodemon --exec \"LOG_LEVEL=debug npm start\"",
     "dev": "nodemon --exec \"npm start\"",
-    "start": "probot run ./index.js",
-    "test": "jest"
+    "start": "probot run ./taskreader.js",
+    "test": "jest",
+    "funcstar": "npx functions-framework --target=probotApp --port=3000 --signature-type=http"
   },
   "dependencies": {
+    "body-parser": "^1.20.2",
     "marked": "^4.0.10",
     "probot": "^12.2.2"
   },
   "devDependencies": {
+    "@google-cloud/functions-framework": "^3.2.0",
     "jest": "^27.4.7",
-    "smee-client": "1.1"
+    "smee-client": "^1.2.3"
   },
   "engines": {
-    "node": "8.9",
-    "npm": "5.6"
+    "node": "16.20",
+    "npm": "9.6.4"
   }
 }

--- a/taskreader.js
+++ b/taskreader.js
@@ -1,4 +1,7 @@
-const checkOutstandingTasks = require('./src/check-outstanding-tasks');
+/**
+ * @param {import('probot').Probot} app
+ */
+const checkOutstandingTasks=require('./src/check-outstanding-tasks');
 
 const ENABLE_ID_LOGS = true; // simple ID only logs, no private repo data logged
 


### PR DESCRIPTION
Note: 
This is how to deploying to gcloud functions using gcloud cli
```gcloud functions deploy  task-list-completed --runtime=nodejs16 --source=. --entry-point=probotApp --trigger-http --allow-unauthenticated --env-vars-file=./.env.yaml
```

.env consists of
```
APP_ID=<redact>
WEBHOOK_SECRET=<redact>
PRIVATE_KEY_PATH=".data/<redact>.pem"


# WEBHOOK_PROXY_URL=<REDACT_for local dev>
GITHUB_CLIENT_ID=<REDACT>
GITHUB_CLIENT_SECRET=<REDACT>
PORT=3000
```

and .env.yaml is mostly the above converted to yaml with the exceptions of:
* PRIVATE_KEY replaces PRIVATE_KEY_PATH with the contents being a multiline string consisting of the PK